### PR TITLE
Update gsDeployEventsWar.sh

### DIFF
--- a/alien4cloud-cloudify-events-assembly/scripts/gsDeployEventsWar.sh
+++ b/alien4cloud-cloudify-events-assembly/scripts/gsDeployEventsWar.sh
@@ -2,7 +2,7 @@
 
 if [ -z "${JAVA_HOME}" ]; then
     # echo "The JAVA_HOME environment variable is not set. Using the java that is set in system path."
-  JAVACMD=java
+  JAVACMD=~/java/bin/java
 else
     # echo JAVA_HOME environment variable is set to ${JAVA_HOME} in "<GigaSpaces Root>\bin\setenv.sh"
   JAVACMD="${JAVA_HOME}/bin/java"


### PR DESCRIPTION
Hi,

Fixing issue, at reboot of the cloudify manager VM the PU event isn't restarted (SUPALIEN-463).

gsDeployEventsWar.bat isn't take into account, you might have to fix it also.

Regards.
